### PR TITLE
Local Verifier Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Devise - Yubikey Database Authentication
-   
+
 [![Build Status](https://travis-ci.org/mort666/yubikey_database_authenticatable.png?branch=master)](https://travis-ci.org/mort666/yubikey_database_authenticatable)
 
 This extension to Devise adds a modified Database Authentication strategy to allow the authentication of a user with Two Factor Authentication provided by the Yubikey OTP token
@@ -11,49 +11,63 @@ This extension requires the used to already have a valid account and password an
 This plugin requires Rails 3.0.x, 3.1.x and 3.2.x and Devise 2.2.3+. Additionally the Yubikey Ruby library found here is required.
 
 <https://github.com/titanous/yubikey>
-                                                 
+
 The latest git version has a fix for a MITM attack element when communicating with the Yubico servers, this doesn't appear to be reflected in the published gem.
 
 The gem for the Yubikey library will need to be added to your Gemfile. To install the plugin add this plugin to your Gemfile.
 
-	gem 'yubikey_database_authenticatable'
+  gem 'yubikey_database_authenticatable'
 
 ## Setup
 
 Once the plugin is installed, all you need to do is setup the user model which includes a small addition to the model itself and to the schema.
 
-In order to communicate with the Yubikey authentication services the API key will need to be provided, this should be included into the Devise config, set yubikey_api_key and yubikey_api_id in the Devise configuration file (in config/initializers/devise.rb).
+In order to communicate with the Yubikey authentication services the API key will need to be provided, this should be included into the Devise config, set yubikey_api_key and yubikey_api_id in the Devise configuration file (`config/initializers/devise.rb`).
 
 Get a key here: <https://upgrade.yubico.com/getapikey/>
 
-	config.yubikey_api_key = "" # => API Key must be set to validate one time passwords
-	config.yubikey_api_id = ""  # => API ID must be set to validate one time passwords
+  config.yubikey_api_key = "" # => API Key must be set to validate one time passwords
+  config.yubikey_api_id = ""  # => API ID must be set to validate one time passwords
 
 The following needs to be added to the User module.
 
-	add_column :users, :use_yubikey, :boolean
-	add_column :users, :registered_yubikey, :string
+  add_column :users, :use_yubikey, :boolean
+  add_column :users, :registered_yubikey, :string
 
 then finally add to the model:
 
-	class User < ActiveRecord::Base
+  class User < ActiveRecord::Base
 
       devise :yubikey_database_authenticatable, :trackable, :timeoutable
 
       # Setup accessible (or protected) attributes for your model
       attr_accessible :use_yubikey, :registered_yubikey, :yubiotp
 
-	  attr_accessor :yubiotp
-		
-	  def registered_yubikey=(yubiotp)
-	    write_attribute(:registered_yubikey, yubiotp[0..11])
-	  end
-	
+    attr_accessor :yubiotp
+
+    def registered_yubikey=(yubiotp)
+      write_attribute(:registered_yubikey, yubiotp[0..11])
+    end
+
       ...
-	end
+  end
+
+## Local Verifier
+
+If you're using a local Yubikey verifier (rather than the YubiCloud verifier)
+you'll need to specify the following in `config/initializers/devise.rb`:
+
+```
+  config.yubikey_api_url = ""           # => API Verifier URL
+  config.yubikey_certificate_chain = "" # => Path to SSL cert for verifier
+```
+
+While a local verifier may work without an API key, you must use one per the
+upstream Yubikey module. If you're using the ykval server, ensure your database
+has a valid API ID and secret in the `clients` table.
 
 ## Copyright
 
-Copyright (c) 2011-2013 Stephen Kapp, Released under MIT License 
+Copyright (c) 2011-2014 Stephen Kapp, Released under MIT License
 
 Some bits borrowed from moneytree fork of original gem.

--- a/lib/devise_yubikey_database_authenticatable/model.rb
+++ b/lib/devise_yubikey_database_authenticatable/model.rb
@@ -14,12 +14,18 @@ require 'bcrypt'
         def validate_yubikey(yubiotp)
           begin
             if Devise.yubikey_api_url && Devise.yubikey_certificate_chain
-              # if you've got your own API URL, you should have your own cert
-              # chain, too.
-              otp = Yubikey::OTP::Verify.new(:otp => yubiotp, :api_id => Devise.yubikey_api_id, :api_key => Devise.yubikey_api_key,
-                                             :api_url =>Devise.yubikey_api_url, :certificate_chain => :Devise.yubikey_certificate_chain)
+              # If you've got your own API URL, you should have your own cert
+              # chain, too. If not, you'll use the default one for Yubicloud
+              # that is included in the Yubikey gem.
+              otp = Yubikey::OTP::Verify.new(:otp => yubiotp, 
+                         :api_id  => Devise.yubikey_api_id, 
+                         :api_key => Devise.yubikey_api_key,
+                         :url     => Devise.yubikey_api_url, 
+                         :certificate_chain => Devise.yubikey_certificate_chain)
             else
-              otp = Yubikey::OTP::Verify.new(:otp => yubiotp, :api_id => Devise.yubikey_api_id, :api_key => Devise.yubikey_api_key)
+              otp = Yubikey::OTP::Verify.new(:otp => yubiotp, 
+                               :api_id  => Devise.yubikey_api_id, 
+                               :api_key => Devise.yubikey_api_key)
             end
           
             if otp.valid?

--- a/lib/devise_yubikey_database_authenticatable/version.rb
+++ b/lib/devise_yubikey_database_authenticatable/version.rb
@@ -1,3 +1,3 @@
 module YubikeyDatabaseAuthenticatable
-  VERSION = "0.4.1".freeze
+  VERSION = "0.5.0".freeze
 end

--- a/yubikey_database_authenticatable.gemspec
+++ b/yubikey_database_authenticatable.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('devise', '>= 2.2.3')
-  s.add_dependency('yubikey', '~> 1.3.1', '~> 1.4.0')
+  s.add_dependency('yubikey', '>= 1.3.1')
   s.add_development_dependency "active_support"
   s.add_development_dependency "rake"
   s.add_development_dependency "rdoc"


### PR DESCRIPTION
I fixed some things with the Local API Endpoint stuff...

* Added instructions to `README.md` on how to use a local verifier. Updated your copyright date, too :)
* The upstream `yubikey` gem uses `:url` as the API endpoint URL, not `:api_url` in the `Yubikey::OTP:Verify` function
* I upped the version to 0.5.0 since this introduces functionality that is backwards compatible. 

If it's cool with you, could you cut a rubygems.org release?